### PR TITLE
Updated types for batchLru to use generics

### DIFF
--- a/batch/index.d.ts
+++ b/batch/index.d.ts
@@ -1,29 +1,10 @@
-/**
- * From https://github.com/sindresorhus/type-fest/
- * Matches any valid JSON value.
- */
-type value = string | number | boolean | JsonObject | JsonArray | null;
-
-/**
- * From https://github.com/sindresorhus/type-fest/
- * Matches a JSON object.
- * This type can be useful to enforce some input to be JSON-compatible or as a super-type to be extended from.
- */
-type JsonObject = {[Key in string]?: value};
-
-/**
- * From https://github.com/sindresorhus/type-fest/
- * Matches a JSON array.
- */
-interface JsonArray extends Array<value> {}
-
-declare function batchLru(
+declare function batchLru<T>(
   maxItems: number,
   ttl: number,
-  callback: (items: JsonArray) => void,
+  callback: (items: T[]) => void,
   timeout?: number,
 ): {
-  add: (item: value) => void;
+  add: (item: T) => void;
 };
 
 // EXPORTS //


### PR DESCRIPTION
This patch allows the user to define exactly the types that's going to be added. 

```
const bulkAdder = batchLru<string>(50, 100, items => {
  // do something with items
});

bulkAdder.add(1); // type error, not a string
bulkAdder.add('hello'); // valid!
```